### PR TITLE
[PHP/Nginx-unit] Fix PID issue during Unit "docker-entrypoint" starting

### DIFF
--- a/dockerfile/php/7.2/unit/docker-entrypoint.sh
+++ b/dockerfile/php/7.2/unit/docker-entrypoint.sh
@@ -31,7 +31,7 @@ if [ "$1" = "unitd" ]; then
     else
         if /usr/bin/find "/docker-entrypoint.d/" -mindepth 1 -print -quit 2>/dev/null | /bin/grep -q .; then
             echo "$0: /docker-entrypoint.d/ is not empty, launching Unit daemon to perform initial configuration..."
-            /usr/sbin/unitd --user root --group root --log /var/log/nginx-unit/nginx-unit.log --control unix:/usr/local/nginx-unit/control.unit.sock
+            /usr/sbin/unitd --user root --group root --log /var/log/nginx-unit/nginx-unit.log --pid /var/run/unit.pid --control unix:/usr/local/nginx-unit/control.unit.sock
 
             while [ ! -S /usr/local/nginx-unit/control.unit.sock ]; do echo "$0: Waiting for control socket to be created..."; /bin/sleep 0.1; done
             # even when the control socket exists, it does not mean unit has finished initialisation

--- a/dockerfile/php/7.3/unit/docker-entrypoint.sh
+++ b/dockerfile/php/7.3/unit/docker-entrypoint.sh
@@ -31,7 +31,7 @@ if [ "$1" = "unitd" ]; then
     else
         if /usr/bin/find "/docker-entrypoint.d/" -mindepth 1 -print -quit 2>/dev/null | /bin/grep -q .; then
             echo "$0: /docker-entrypoint.d/ is not empty, launching Unit daemon to perform initial configuration..."
-            /usr/sbin/unitd --user root --group root --log /var/log/nginx-unit/nginx-unit.log --control unix:/usr/local/nginx-unit/control.unit.sock
+            /usr/sbin/unitd --user root --group root --log /var/log/nginx-unit/nginx-unit.log --pid /var/run/unit.pid --control unix:/usr/local/nginx-unit/control.unit.sock
 
             while [ ! -S /usr/local/nginx-unit/control.unit.sock ]; do echo "$0: Waiting for control socket to be created..."; /bin/sleep 0.1; done
             # even when the control socket exists, it does not mean unit has finished initialisation

--- a/dockerfile/php/7.4/unit/docker-entrypoint.sh
+++ b/dockerfile/php/7.4/unit/docker-entrypoint.sh
@@ -31,7 +31,7 @@ if [ "$1" = "unitd" ]; then
     else
         if /usr/bin/find "/docker-entrypoint.d/" -mindepth 1 -print -quit 2>/dev/null | /bin/grep -q .; then
             echo "$0: /docker-entrypoint.d/ is not empty, launching Unit daemon to perform initial configuration..."
-            /usr/sbin/unitd --user root --group root --log /var/log/nginx-unit/nginx-unit.log --control unix:/usr/local/nginx-unit/control.unit.sock
+            /usr/sbin/unitd --user root --group root --log /var/log/nginx-unit/nginx-unit.log --pid /var/run/unit.pid --control unix:/usr/local/nginx-unit/control.unit.sock
 
             while [ ! -S /usr/local/nginx-unit/control.unit.sock ]; do echo "$0: Waiting for control socket to be created..."; /bin/sleep 0.1; done
             # even when the control socket exists, it does not mean unit has finished initialisation


### PR DESCRIPTION
Fixes a bug where "docker-entrypoint" could not find the PID file unitd daemon. This results in an error where the Nginx unit does not load.